### PR TITLE
updates to build on OCaml 5.2.0

### DIFF
--- a/datalog.opam
+++ b/datalog.opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "dune"
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "5.2.0" }
   "odoc" {with-doc}
   "mdx" { >= "1.3" & with-test}
 ]

--- a/src/bottom_up_cli/datalog_cli.ml
+++ b/src/bottom_up_cli/datalog_cli.ml
@@ -56,7 +56,7 @@ let handle_goal db lit =
     try
       let a = int_of_string (DSym.to_string a)
       and b = int_of_string (DSym.to_string b) in
-      Pervasives.compare a b
+      Stdlib.compare a b
     with Invalid_argument _ -> compare a b
   in
   match (DLogic.open_literal lit :> string * DLogic.term list) with


### PR DESCRIPTION
Hello, there! Thank you for writing this useful package. I'm submitting a patch that allows it to be installed under the current version of OCaml. Please let me know if there are any further modifications you'd like me to make.

- Needed to increase the lower bound (but I found this behaviour of opam confusing: it seems that lower bounds introduce an implicit upper bound, as installing the package as-written leads to opam trying to downgrade the OCaml compiler)

- Handling the renaming of Pervasives to Stdlib


Thanks very much,
Jon
