### PR TITLE
Update to dune 2.7

### DIFF
--- a/datalog.opam
+++ b/datalog.opam
@@ -9,13 +9,13 @@ tags: ["datalog" "relational" "query" "prolog"]
 homepage: "https://github.com/c-cube/datalog"
 bug-reports: "https://github.com/c-cube/datalog/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7" & >= "2.7"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
   "mdx" {>= "1.3" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.7)
 (generate_opam_files true)
 
 (name datalog)
@@ -13,7 +13,7 @@
  (synopsis "An in-memory datalog implementation for OCaml")
  (tags (datalog relational query prolog))
  (depends
-  (dune ( >= "2.0" ))
+  (dune ( >= "2.7" ))
   (ocaml ( >= "4.08" ))
   (odoc :with-doc)
   (mdx (and ( >= "1.3" ) :with-test))))


### PR DESCRIPTION
This will ensure the the generated opam file doesn't have the erroneous config noted in https://github.com/ocaml/dune/pull/3647

Followup to https://github.com/ocaml/opam-repository/pull/26751